### PR TITLE
Remove Sola from Adeste Fideles

### DIFF
--- a/ly/unmapped/Adeste Fideles.ly
+++ b/ly/unmapped/Adeste Fideles.ly
@@ -149,7 +149,7 @@ altoWordsIII = \lyricmode {
   \set ignoreMelismata = ##t
   _ Can -- tet nunc ‘I -- o,’ cho -- rus an -- ge -- lo -- _ rum_; ""
   Can -- tet nunc au -- _ la __ _ cæ -- les -- ti -- um,
-  Glo -- ri -- _ a! __ _ So -- li De -- o Glo -- ri -- a!
+  Glo -- ri -- _ a __ _ in ex -- cel -- sis De -- _ o!
 }
 altoWordsIV = \lyricmode {
   \dropLyricsV


### PR DESCRIPTION
The original text of Adeste Fideles has "Gloria in excelsis Deo" as opposed to "Gloria! Soli Deo gloria!", which references one of the 5 solæ from the Reformation. The English text used, "Glory in the highest", already matches this revision/reversion.